### PR TITLE
Simpler SQS support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,19 +16,24 @@
         "evenement/evenement": "1.0.*@stable"
     },
     "require-dev": {
+        "chh/bob": "1.0.*@dev",
+        "phpunit/phpunit": "~3.7",
         "symfony/console": "2.1.*@stable",
         "monolog/monolog": "1.2.*@stable",
-        "mtdowling/cron-expression": "1.*"
+        "mtdowling/cron-expression": "1.*",
+        "aws/aws-sdk-php": "~2.1.1"
     },
     "suggest": {
         "ext-redis": "Enable RedisQueue",
         "symfony/console": "Used by the console command",
         "monolog/monolog": "Used by the console command",
-        "mtdowling/cron-expression": "Enable CRON expressions"
+        "mtdowling/cron-expression": "Enable CRON expressions",
+        "aws/aws-sdk-php": "AmazonSqsQueue"
     },
     "autoload": {
         "psr-0": {
-            "Kue": "lib\/"
+            "Kue\\": "lib/",
+            "Kue\\Test\\": "tests/"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "evenement/evenement": "1.0.*@stable"
+        "evenement/evenement": "~1.0"
     },
     "require-dev": {
-        "chh/bob": "1.0.*@dev",
+        "chh/bob": "~1.0@dev",
         "phpunit/phpunit": "~3.7",
-        "symfony/console": "2.1.*@stable",
-        "monolog/monolog": "1.2.*@stable",
-        "mtdowling/cron-expression": "1.*",
+        "symfony/console": "~2.1",
+        "monolog/monolog": "~1.2",
+        "mtdowling/cron-expression": "~1.0",
         "aws/aws-sdk-php": "~2.1.1"
     },
     "suggest": {

--- a/examples/scheduler.php
+++ b/examples/scheduler.php
@@ -3,15 +3,18 @@
 require_once(__DIR__ . '/../vendor/autoload.php');
 require_once(__DIR__ . '/job.php');
 
+use Kue\Scheduler\Time;
+
 $scheduler = new Kue\Scheduler(new Kue\LocalQueue);
 
-$scheduler->every('20 seconds', new HelloJob);
-$scheduler->every('30 seconds', new FooJob);
+$scheduler->every(20*Time::SECOND, new HelloJob);
+$scheduler->every(30*Time::SECOND, new FooJob);
 
 $scheduler->cron('*/5 * * * *', new CronJob);
 
 for (;;) {
     var_dump($scheduler->run());
+    var_dump(date('Y-m-d H:i:s'));
     //sleep(1);
 }
 

--- a/lib/Kue/AmazonSqsQueue.php
+++ b/lib/Kue/AmazonSqsQueue.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Kue;
+
+use Aws\Sqs\SqsClient;
+
+class AmazonSqsQueue implements Queue
+{
+    protected $client;
+    protected $queueUrl;
+    protected $queueName;
+
+    protected $jobs = array();
+
+    function __construct($queueName, array $config)
+    {
+        $this->queueName = $queueName;
+        $this->client = SqsClient::factory($config);
+    }
+
+    function push(Job $job)
+    {
+        $this->jobs[] = $job;
+    }
+
+    function pop()
+    {
+        $response = $this->client->receiveMessage(array(
+            'QueueUrl' => $this->queueUrl(),
+            'MaxNumberOfMessages' => 1
+        ));
+
+        $messages = $response->get('Messages');
+
+        if (!$messages) {
+            return;
+        }
+
+        $job = unserialize(rawurldecode($messages[0]['Body']));
+        $job->_amazonSqsReceiptHandle = $messages[0]['ReceiptHandle'];
+
+        return $job;
+    }
+
+    function deleteJob(Job $job)
+    {
+        if (!isset($job->_amazonSqsReceiptHandle)) {
+            throw new \InvalidArgumentException("Job is not a valid Amazon SQS job");
+        }
+
+        $this->client->deleteMessage(array(
+            'QueueUrl' => $this->queueUrl(),
+            'ReceiptHandle' => $job->_amazonSqsReceiptHandle
+        ));
+    }
+
+    function flush()
+    {
+        $messages = array_map(function(Job $job) {
+            $body = serialize($job);
+            $id = sha1($body . uniqid());
+
+            return array(
+                'Id' => $id,
+                'MessageBody' => rawurlencode($body)
+            );
+        }, $this->jobs);
+
+        $response = $this->client->sendMessageBatch(array(
+            'QueueUrl' => $this->queueUrl(),
+            'Entries' => $messages
+        ));
+
+        if ($failed = $response->get('Failed')) {
+            $message = "Errors occured while sending the jobs:\n\n";
+
+            $message .= join("\n", array_map(function($error) {
+                return sprintf("[%s] %s: %s\n", $error['Id'], $error['Code'], $error['Message']);
+            }, $failed));
+
+            throw new \UnexpectedValueException($message);
+        }
+    }
+
+    protected function queueUrl()
+    {
+        if (null === $this->queueUrl) {
+            $this->queueUrl = $this->client->getQueueUrl(array("QueueName" => $this->queueName))->get('QueueUrl');
+        }
+
+        return $this->queueUrl;
+    }
+}

--- a/lib/Kue/AmazonSqsQueue.php
+++ b/lib/Kue/AmazonSqsQueue.php
@@ -96,4 +96,8 @@ class AmazonSqsQueue implements Queue
 
         return $this->queueUrl;
     }
+
+    function process(Worker $worker)
+    {
+    }
 }

--- a/lib/Kue/ArrayQueue.php
+++ b/lib/Kue/ArrayQueue.php
@@ -25,4 +25,7 @@ class ArrayQueue implements Queue
 
     function flush()
     {}
+
+    function process(Worker $worker)
+    {}
 }

--- a/lib/Kue/LocalQueue.php
+++ b/lib/Kue/LocalQueue.php
@@ -105,7 +105,7 @@ class LocalQueue implements Queue
     {
         $server = $this->server();
 
-        $r = [$server];
+        $r = array($server);
         $w = null;
         $x = null;
 

--- a/lib/Kue/PreforkingWorker.php
+++ b/lib/Kue/PreforkingWorker.php
@@ -62,10 +62,7 @@ class PreforkingWorker extends EventEmitter implements Worker
         $this->selfPipe = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
 
         $this->queue = $queue;
-
-        if (is_callable(array($queue, 'process'))) {
-            $queue->process($this);
-        }
+        $queue->process($this);
 
         # Spawn up the initial worker pool.
         $this->spawnWorkers();

--- a/lib/Kue/Queue.php
+++ b/lib/Kue/Queue.php
@@ -37,5 +37,12 @@ interface Queue
      * @return void
      */
     function flush();
-}
 
+    /**
+     * Gets called when the queue is registered with a Worker instance.
+     *
+     * Can be used by the queue to setup custom event handlers for worker events, to e.g. 
+     * handle failed jobs.
+     */
+    function process(Worker $worker);
+}

--- a/lib/Kue/RedisQueue.php
+++ b/lib/Kue/RedisQueue.php
@@ -51,5 +51,8 @@ class RedisQueue implements Queue
     {
         # We send jobs directly in `push`, so we don't need to flush
     }
-}
 
+    function process(Worker $worker)
+    {
+    }
+}

--- a/lib/Kue/Scheduler.php
+++ b/lib/Kue/Scheduler.php
@@ -7,10 +7,11 @@ use DateInterval;
 
 use Kue\Scheduler\Expression;
 use Kue\Scheduler\CronExpression;
-use Kue\Scheduler\SimpleDateStringExpression;
+use Kue\Scheduler\SimpleExpression;
 
 /**
- * Simple, tickless scheduler which puts jobs into the queue.
+ * Simple, tickless scheduler which puts jobs into the queue when
+ * expressions are due.
  *
  * @author Christoph Hochstrasser <christoph.hochstrasser@gmail.com>
  */
@@ -27,14 +28,14 @@ class Scheduler
     /**
      * Adds the job to the scheduler.
      *
-     * @param string $interval Any string accepted by DateInterval::createFromDateString()
+     * @param int $interval Interval in seconds
      * @param Job $job
      *
      * @return Scheduler
      */
     function every($interval, Job $job)
     {
-        $expression = new SimpleDateStringExpression($interval);
+        $expression = new SimpleExpression($interval);
         $this->add($expression, $job);
 
         return $this;

--- a/lib/Kue/Scheduler/SimpleExpression.php
+++ b/lib/Kue/Scheduler/SimpleExpression.php
@@ -5,16 +5,13 @@ namespace Kue\Scheduler;
 use DateTime;
 use DateInterval;
 
-class SimpleDateStringExpression implements Expression
+class SimpleExpression implements Expression
 {
     protected $expression;
-    protected $interval;
 
     function __construct($expression)
     {
-        # Only for reference
         $this->expression = $expression;
-        $this->interval = DateInterval::createFromDateString($expression);
     }
 
     function getNextRunDate($currentTime = 'now')
@@ -25,10 +22,7 @@ class SimpleDateStringExpression implements Expression
             $now = new DateTime($currentTime);
         }
 
-        $then = clone $now;
-        $then->add($this->interval);
-
-        $duration = $then->getTimestamp() - $now->getTimestamp();
+        $duration = $this->expression;
 
         $date = new DateTime;
         $date->setTimestamp($now->getTimestamp() + ($duration - ($now->getTimestamp() % $duration)));
@@ -42,10 +36,7 @@ class SimpleDateStringExpression implements Expression
             $currentTime = new \DateTime('now');
         }
 
-        $then = clone $currentTime;
-        $then->add($this->interval);
-
-        $duration = $then->getTimestamp() - $currentTime->getTimestamp();
+        $duration = $this->expression;
 
         return $currentTime->getTimestamp() % $duration === 0;
     }

--- a/lib/Kue/Scheduler/Time.php
+++ b/lib/Kue/Scheduler/Time.php
@@ -2,10 +2,10 @@
 
 namespace Kue\Scheduler;
 
-interface Time
+final class Time
 {
     const SECOND = 1;
-    const HOUR = 3600;
     const MINUTE = 60;
+    const HOUR = 3600;
     const DAY = 86400;
 }

--- a/lib/Kue/Scheduler/Time.php
+++ b/lib/Kue/Scheduler/Time.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Kue\Scheduler;
+
+interface Time
+{
+    const SECOND = 1;
+    const HOUR = 3600;
+    const MINUTE = 60;
+    const DAY = 86400;
+}

--- a/lib/Kue/SequentialWorker.php
+++ b/lib/Kue/SequentialWorker.php
@@ -8,6 +8,8 @@ class SequentialWorker extends EventEmitter implements Worker
 {
     function process(Queue $queue)
     {
+        $queue->process($this);
+
         for (;;) {
             $job = $queue->pop();
 

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -1,5 +1,11 @@
 <phpunit bootstrap="./tests/bootstrap.php">
     <php>
+        <!--
+        <env name="AWS_ACCESS_KEY" value="" />
+        <env name="AWS_SECRET_KEY" value="" />
+        <env name="AWS_REGION" value="" />
+        <env name="SQS_QUEUE_NAME" value="kue_test" />
+        -->
     </php>
     <testsuites>
         <testsuite name="kue Test Suite">

--- a/tests/Kue/Test/AmazonSqsQueueTest.php
+++ b/tests/Kue/Test/AmazonSqsQueueTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Kue\Test;
+
+use Kue\AmazonSqsQueue;
+use Aws\Common\Enum\Region;
+
+class AmazonSqsQueueTest extends \PHPUnit_Framework_TestCase
+{
+    protected $queue;
+    protected $jobsToDelete = array();
+
+    function setup()
+    {
+        $this->queue = new AmazonSqsQueue($_ENV['SQS_QUEUE_NAME'], array(
+            'key' => $_ENV['AWS_ACCESS_KEY'],
+            'secret' => $_ENV['AWS_SECRET_KEY'],
+            'region' => $_ENV['AWS_REGION'],
+        ));
+    }
+
+    function test()
+    {
+        $in = new TestJob("Hello World");
+
+        $this->queue->push($in);
+        $this->queue->flush();
+
+        $out = $this->queue->pop();
+
+        $this->assertNotNull($out);
+
+        $this->jobsToDelete[] = $out;
+
+        $this->assertEquals($in->getMessage(), $out->getMessage());
+    }
+
+    function tearDown()
+    {
+        foreach ($this->jobsToDelete as $job) {
+            $this->queue->deleteJob($job);
+        }
+    }
+}

--- a/tests/Kue/Test/SchedulerTest.php
+++ b/tests/Kue/Test/SchedulerTest.php
@@ -6,13 +6,6 @@ use Kue\Scheduler;
 use Kue\Scheduler\Time as t;
 use Kue\ArrayQueue;
 
-class TestJob implements \Kue\Job
-{
-    function run()
-    {
-    }
-}
-
 class SchedulerTest extends \PHPUnit_Framework_TestCase
 {
     function testRunReturnsNumberOfJobsScheduled()
@@ -21,7 +14,7 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
         $queue->expects($this->once())->method('push');
 
         $scheduler = new Scheduler($queue);
-        $scheduler->every(1*t::SECOND, new TestJob);
+        $scheduler->every(1*t::SECOND, new TestJob("Hello World"));
 
         $this->assertEquals(1, $scheduler->run());
     }

--- a/tests/Kue/Test/SchedulerTest.php
+++ b/tests/Kue/Test/SchedulerTest.php
@@ -3,6 +3,7 @@
 namespace Kue\Test;
 
 use Kue\Scheduler;
+use Kue\Scheduler\Time as t;
 use Kue\ArrayQueue;
 
 class TestJob implements \Kue\Job
@@ -20,7 +21,7 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
         $queue->expects($this->once())->method('push');
 
         $scheduler = new Scheduler($queue);
-        $scheduler->every('1 seconds', new TestJob);
+        $scheduler->every(1*t::SECOND, new TestJob);
 
         $this->assertEquals(1, $scheduler->run());
     }

--- a/tests/Kue/Test/TestJob.php
+++ b/tests/Kue/Test/TestJob.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Kue\Test;
+
+class TestJob implements \Kue\Job
+{
+    protected $message;
+
+    function __construct($message)
+    {
+        $this->message = $message;
+    }
+
+    function getMessage()
+    {
+        return $this->message;
+    }
+
+    function run()
+    {
+    }
+}
+


### PR DESCRIPTION
This implements support for Amazon SQS in a simple way with the `AmazonSqsQueue` class.

You need the `aws/aws-sdk` package installed in at least version `2.1`.

Example:

``` php
<?php

use Kue\AmazonSqsQueue;
use Aws\Common\Enum\Region;

$queue = new AmazonSqsQueue("my-queue", array(
  'key' => '…',
  'secret' => '…',
  'region' => Region::US_EAST_1
));

$queue->push($job);
```

The `AmazonSqsQueue` has also a special `->deleteJob()` method which takes a `Job` instance. This can be hooked up to the worker's `success` event to automatically delete finished jobs from the queue.

``` php
<?php

use Kue\Command\WorkCommand;
use Kue\Job;

$app = new \Symfony\Component\Console\Application('example');

$work = new WorkCommand($queue, array(
  'success' => function(Job $job) use ($queue) {
    $queue->deleteJob($job);
  }
));

$app->add($work);

$app->run()
```
