### PR TITLE
Fixed reference to queue instance var in ArrayQueue

### DIFF
--- a/lib/Kue/ArrayQueue.php
+++ b/lib/Kue/ArrayQueue.php
@@ -13,7 +13,7 @@ class ArrayQueue implements Queue
 
     function pop()
     {
-        if (count($queue) > 0) {
+        if (count($this->queue) > 0) {
             return array_pop($this->queue);
         }
     }


### PR DESCRIPTION
A pretty simple bug fix. Cheers!
